### PR TITLE
Firefox sync server

### DIFF
--- a/includes/config/other-services-available
+++ b/includes/config/other-services-available
@@ -15,6 +15,7 @@ Filebot-filebot
 Filebrowser-SelfHostedFileSyncAndSharing
 Filerun-SelfHostedFileSyncAndSharing
 Firefox-MozillaFirefoxFreeOpenSourceWebBrowser
+Firefoxsyncserver-MozillaFirefoxSynchronisationServer
 Freshrss-SelfHostableAggregator
 Gitlab-GitLabDockerImages
 Gitea-GitCommunityLightweightCode

--- a/includes/dockerapps/pretasks/firefoxsyncserver.yml
+++ b/includes/dockerapps/pretasks/firefoxsyncserver.yml
@@ -1,0 +1,13 @@
+---
+- name: Set 'secret_connect' variable
+  set_fact:
+    secret_connect: "{{lookup('community.general.random_string', length=20, special=false)}}"
+
+- name: Set 'nom_court' variable
+  set_fact:
+    nom_court: "{{sub[pgrole][pgrole] if sub_enabled else pgrole}}"
+
+- name: Set 'url_public' variable
+  set_fact:
+    url_public: "http://{{ nom_court }}.{{ user.domain }}"
+

--- a/includes/dockerapps/vars/firefoxsyncserver.yml
+++ b/includes/dockerapps/vars/firefoxsyncserver.yml
@@ -9,4 +9,8 @@ pg_env:
   PUID: "{{ lookup('env','MYUID') }}"
   PGID: "{{ lookup('env','MYGID') }}"
   Z: "Europe/Paris"
-  FF_SYNCSERVER_SECRET: "unsecrettrestresfacilepourletest"
+  FF_SYNCSERVER_SECRET: "{{ secret_connect }}"
+  SYNCSERVER_PUBLIC_URL: "{{ url_public }}"
+  SYNCSERVER_BATCH_UPLOAD_ENABLED: 'true'
+  SYNCSERVER_FORCE_WSGI_ENVIRON: 'false'
+  SYNCSERVER_DEBUG_ENABLED: 'true'

--- a/includes/dockerapps/vars/firefoxsyncserver.yml
+++ b/includes/dockerapps/vars/firefoxsyncserver.yml
@@ -1,0 +1,12 @@
+---
+pgrole: 'firefoxsyncserver'
+intport: '5000'
+image: 'crazymax/firefox-syncserver:latest'
+pg_volumes:
+  - "{{ lookup('env','CONFDIR') }}/docker/{{ lookup('env','USER') }}/{{ pgrole }}/config:/data:rw"
+  - "/etc/localtime:/etc/localtime:ro"
+pg_env:
+  PUID: "{{ lookup('env','MYUID') }}"
+  PGID: "{{ lookup('env','MYGID') }}"
+  Z: "Europe/Paris"
+  FF_SYNCSERVER_SECRET: "unsecrettrestresfacilepourletest"

--- a/includes/dockerapps/vars/firefoxsyncserver.yml
+++ b/includes/dockerapps/vars/firefoxsyncserver.yml
@@ -8,9 +8,11 @@ pg_volumes:
 pg_env:
   PUID: "{{ lookup('env','MYUID') }}"
   PGID: "{{ lookup('env','MYGID') }}"
-  Z: "Europe/Paris"
+  TZ: "Europe/Paris"
   FF_SYNCSERVER_SECRET: "{{ secret_connect }}"
-  SYNCSERVER_PUBLIC_URL: "{{ url_public }}"
+  FF_SYNCSERVER_PUBLIC_URL: "{{ url_public }}"
   SYNCSERVER_BATCH_UPLOAD_ENABLED: 'true'
-  SYNCSERVER_FORCE_WSGI_ENVIRON: 'false'
+  FF_SYNCSERVER_FORCE_WSGI_ENVIRON: 'false'
   SYNCSERVER_DEBUG_ENABLED: 'true'
+  FF_SYNCSERVER_ALLOW_NEW_USERS: 'true'
+  FF_SYNCSERVER_LOGLEVEL: info


### PR DESCRIPTION
Permet d'auto héberger un serveur de synchronisation pour Firefox.
Aide pour configurer Firefox:
    Commencer par aller dans la configuration avancée en tapant about:config dans la barre d’URL
    Rechercher ensuite le champ: identity.sync.tokenserver.uri
    Y entrer votre URL du type: https://syncserver.mondomaine.fr/token/1.0/sync/1.5
    Vous pouvez ensuite (après avoir redémarré Firefox*, ça n’a pas marché chez moi sans le faire*) vous connecter et synchroniser vos données !

Comment synchroniser manuellement les données 