### PR TITLE
Update n8nio.yml avec postgresqldb (mysql non soutenu)

### DIFF
--- a/includes/dockerapps/vars/n8nio.yml
+++ b/includes/dockerapps/vars/n8nio.yml
@@ -1,4 +1,3 @@
----
 pgrole: 'n8nio'
 intport: '5678'
 image: 'n8nio/n8n'
@@ -6,15 +5,21 @@ pg_volumes:
   - "{{ settings.storage }}/docker/{{ lookup('env','USER') }}/{{ pgrole }}/config:/home/node/.n8n:rw"
   - '/etc/localtime:/etc/localtime:ro'
 pg_env:
-  DB_TYPE: "mysqldb"
-  DB_MYSQLDB_DATABASE: "{{ pgrole }}"
-  DB_MYSQLDB_HOST: "db-{{ pgrole }}"
-  DB_MYSQLDB_PORT: "3306"
-  DB_MYSQLDB_USER: "{{ pgrole }}"
-  DB_MYSQLDB_PASSWORD: "{{ pgrole }}"
+  DB_TYPE: "postgresdb"
+  DB_POSTGRESDB_DATABASE: "{{ pgrole }}"
+  DB_POSTGRESDB_HOST: "db-{{ pgrole }}"
+  DB_POSTGRESDB_PORT: "5432"
+  DB_POSTGRESDB_USER: "{{ pgrole }}"
+  DB_POSTGRESDB_PASSWORD: "{{ pgrole }}"
   TZ: "Europe/Paris"
   WEBHOOK_URL: "https://{{sub[pgrole][pgrole] if sub_enabled else pgrole}}.{{ user.domain }}"
+# N8N_LOG_LEVEL: "debug"
   N8N_BASIC_AUTH_ACTIVE: "true"
   N8N_BASIC_AUTH_USER: "{{ user.name }}"
   N8N_BASIC_AUTH_PASSWORD: "{{ user.pass }}"
+
+posttasks:
+  - "postgresqldb"
+
+description: "AutomationTool"
 


### PR DESCRIPTION
Remplacement de mysqldb par postgresqldb (problème consécutif à la dernière mise à jour). 
Par contre nécessaire de faire : 
`docker run --rm -it -v /opt/seedbox/docker/bono2007/n8nio:/home/node/.n8n --entrypoint chown n8nio/base:16 -R node:node /home/node/.n8n
` pour les droits du user 'node' sur le dossier config. 
