### PR TITLE
Update functions.sh python-debian \

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -927,6 +927,7 @@ function premier_lancement() {
     pip
   pip install wheel
   pip install ansible \
+    python-debian \
     docker \
     shyaml \
     netaddr \


### PR DESCRIPTION
## Problème

L'installation Docker échoue systématiquement avec 
`ModuleNotFoundError: No module named 'debian'`, car `python-debian` 
n'est pas installé dans le venv du script alors que le rôle Ansible 
`geerlingguy.docker` en a besoin.

## Correctif

Ajout de `python-debian` à la liste des paquets pip installés dans 
`install_common()` (functions.sh), à côté d'`ansible`.

## Test

Testé sur Ubuntu 22.04, fresh install. Sans le fix : erreur systématique 
sur la tâche `Add or remove Docker repository`. Avec le fix : installation 
Docker/Traefik OK.